### PR TITLE
Make parser check optional fields too.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-type Parser<T> = (value: unknown) => T | null;
+type Parser<T> = (value: unknown) => Required<T> | null;
 
 function hasProperties<T extends object, K extends string>(obj: T, ...keys: K[]): obj is T & { [J in K]: unknown } {
     return !!obj && keys.every(key => obj.hasOwnProperty(key));
 }
 
 
-const createTypeGuard = <T>(parse: Parser<Required<T>>) => (value: unknown): value is T => {
+const createTypeGuard = <T>(parse: Parser<T>) => (value: unknown): value is T => {
     return parse(value) !== null;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ function hasProperties<T extends object, K extends string>(obj: T, ...keys: K[])
 }
 
 
-const createTypeGuard = <T>(parse: Parser<T>) => (value: unknown): value is T => {
+const createTypeGuard = <T>(parse: Parser<Required<T>>) => (value: unknown): value is T => {
     return parse(value) !== null;
 };
 


### PR DESCRIPTION
#13  When creating a Type Guard pass interface with all required fields to the parser but parser still returns the original interface. 